### PR TITLE
fix: remove deprecated field from goreleaser file

### DIFF
--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -38,6 +38,8 @@ builds:
 archives:
   -
     name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -37,9 +37,10 @@ builds:
 
 archives:
   -
-    replacements:
-      386: i386
-      amd64: x86_64
+    name_template: >-
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
Removes the deprecated `replacements` field from the `goreleaser.yaml` file.

Ref: https://goreleaser.com/deprecations/#archivesreplacements