### PR TITLE
chore: enable cgo in goreleaser

### DIFF
--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -7,7 +7,7 @@ before:
 builds:
   -
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
     flags:
       - -tags=static_all
     goos:


### PR DESCRIPTION
Since we now use zstd in CLI, we would need to enable CGO in the goreleaser config.