### PR TITLE
fix: fix goreleaser pipeline for CGO enabled builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,9 @@
 name: goreleaser
 
 on:
-  pull_request:
   push:
-    branches:
-      - master
+    tags:
+      - '*'
 
 permissions:
   contents: write
@@ -24,22 +23,11 @@ jobs:
         with:
           go-version: 1.18
 
-      # - name: Run GoReleaser
-      #   uses: goreleaser/goreleaser-action@v4
-      #   with:
-      #     distribution: goreleaser
-      #     version: latest
-      #     workdir: ./cmd/deepsource
-      #     args: release --clean --skip-publish --skip-validate --config ../../goreleaser.yaml
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #     HOMEBREW_TOKEN: ${{ secrets.DS_BOT_PAT }}
-      #     DEEPSOURCE_CLI_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-
-      - name: setup env
+      - name: Setup environment variables
         run: |-
           echo 'GITHUB_TOKEN=${{secrets.GITHUB_TOKEN}}' > .release-env
           echo 'HOMEBREW_TOKEN=${{secrets.DS_BOT_PAT}}' > .release-env
           echo 'DEEPSOURCE_CLI_SENTRY_DSN=${{secrets.SENTRY_DSN}}' > .release-env
-      - name: release publish
-        run: make release-dry-run
+
+      - name: Publish Release
+        run: make release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,20 +17,28 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          submodules: 'true'
 
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
           go-version: 1.18
 
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v4
-        with:
-          distribution: goreleaser
-          version: latest
-          workdir: ./cmd/deepsource
-          args: release --clean --skip-publish --skip-validate --config ../../goreleaser.yaml
+      # - name: Run GoReleaser
+      #   uses: goreleaser/goreleaser-action@v4
+      #   with:
+      #     distribution: goreleaser
+      #     version: latest
+      #     workdir: ./cmd/deepsource
+      #     args: release --clean --skip-publish --skip-validate --config ../../goreleaser.yaml
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #     HOMEBREW_TOKEN: ${{ secrets.DS_BOT_PAT }}
+      #     DEEPSOURCE_CLI_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+
+      - name: release publish
+        run: make release-dry-run
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TOKEN: ${{ secrets.DS_BOT_PAT }}
-          DEEPSOURCE_CLI_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          echo 'GITHUB_TOKEN=${{secrets.GITHUB_TOKEN}}' > .release-env
+          echo 'HOMEBREW_TOKEN=${{secrets.DS_BOT_PAT}}' > .release-env
+          echo 'DEEPSOURCE_CLI_SENTRY_DSN=${{secrets.SENTRY_DSN}}' > .release-env

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,14 @@
 name: goreleaser
 
+# on:
+#   push:
+#     tags:
+#       - '*'
 on:
+  pull_request:
   push:
-    tags:
-      - '*'
+    branches:
+      - master
 
 permissions:
   contents: write
@@ -30,4 +35,4 @@ jobs:
           echo 'DEEPSOURCE_CLI_SENTRY_DSN=${{secrets.SENTRY_DSN}}' > .release-env
 
       - name: Publish Release
-        run: make release
+        run: make release-dry-run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: master
 
       - name: Set up Go
         uses: actions/setup-go@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,10 @@
 name: goreleaser
 
 on:
+  pull_request:
   push:
-    tags:
-      - '*'
+    branches:
+      - master
 
 permissions:
   contents: write
@@ -13,23 +14,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: master
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: 1.18
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser
           version: latest
           workdir: ./cmd/deepsource
-          args: release --rm-dist --config ../../goreleaser.yaml
+          args: release --clean --skip-publish --skip-validate --config ../../goreleaser.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TOKEN: ${{ secrets.DS_BOT_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,9 @@
 name: goreleaser
 
-# on:
-#   push:
-#     tags:
-#       - '*'
 on:
-  pull_request:
   push:
-    branches:
-      - master
+    tags:
+      - '*'
 
 permissions:
   contents: write
@@ -35,4 +30,4 @@ jobs:
           echo 'DEEPSOURCE_CLI_SENTRY_DSN=${{secrets.SENTRY_DSN}}' > .release-env
 
       - name: Publish Release
-        run: make release-dry-run
+        run: make release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,9 +36,10 @@ jobs:
       #     HOMEBREW_TOKEN: ${{ secrets.DS_BOT_PAT }}
       #     DEEPSOURCE_CLI_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
-      - name: release publish
-        run: make release-dry-run
-        env:
+      - name: setup env
+        run: |-
           echo 'GITHUB_TOKEN=${{secrets.GITHUB_TOKEN}}' > .release-env
           echo 'HOMEBREW_TOKEN=${{secrets.DS_BOT_PAT}}' > .release-env
           echo 'DEEPSOURCE_CLI_SENTRY_DSN=${{secrets.SENTRY_DSN}}' > .release-env
+      - name: release publish
+        run: make release-dry-run

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "sysroot"]
+	path = sysroot
+	url = git@github.com:goreleaser/goreleaser-cross-example-sysroot.git

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ sysroot-unpack:
 
 .PHONY: release-dry-run
 release-dry-run:
-	cd cmd/deepsource
+	pwd
 	@docker run \
 		--rm \
 		-e CGO_ENABLED=1 \
@@ -46,7 +46,7 @@ release-dry-run:
 		-v `pwd`/sysroot:/sysroot \
 		-w /go/src/$(PACKAGE_NAME) \
 		ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
-                release --clean --skip-publish --skip-validate --config ../../goreleaser.yaml
+                release --clean --skip-publish --skip-validate
 
 .PHONY: release
 release:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PACKAGE_NAME          := github.com/DeepSourceCorp/cli
+PACKAGE_NAME          := github.com/deepsourcelabs/cli
 GOLANG_CROSS_VERSION  ?= v1.19.5
 
 SYSROOT_DIR     ?= sysroots
@@ -36,7 +36,10 @@ sysroot-unpack:
 
 .PHONY: release-dry-run
 release-dry-run:
-	pwd
+	@if [ ! -f ".release-env" ]; then \
+		echo "\033[91m.release-env is required for release\033[0m";\
+		exit 1;\
+	fi
 	@docker run \
 		--rm \
 		-e CGO_ENABLED=1 \

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
+PACKAGE_NAME          := github.com/DeepSourceCorp/cli
+GOLANG_CROSS_VERSION  ?= v1.19.5
+
+SYSROOT_DIR     ?= sysroots
+SYSROOT_ARCHIVE ?= sysroots.tar.bz2
+
 build:
 	cd cmd/deepsource && GOOS=linux GOARCH=amd64 go build -tags static_all -o /tmp/deepsource .
 
@@ -16,6 +22,45 @@ test:
 test_setup:
 	mkdir -p ${CODE_PATH}
 	cd ${CODE_PATH} && ls -A1 | xargs rm -rf
-	git clone https://github.com/deepsourcelabs/cli ${CODE_PATH}
+	git clone https://github.com/DeepSourceCorp/cli ${CODE_PATH}
 	chmod +x /tmp/deepsource
 	cp ./command/report/tests/golden_files/python_coverage.xml /tmp
+
+.PHONY: sysroot-pack
+sysroot-pack:
+	@tar cf - $(SYSROOT_DIR) -P | pv -s $[$(du -sk $(SYSROOT_DIR) | awk '{print $1}') * 1024] | pbzip2 > $(SYSROOT_ARCHIVE)
+
+.PHONY: sysroot-unpack
+sysroot-unpack:
+	@pv $(SYSROOT_ARCHIVE) | pbzip2 -cd | tar -xf -
+
+.PHONY: release-dry-run
+release-dry-run:
+	cd cmd/deepsource
+	@docker run \
+		--rm \
+		-e CGO_ENABLED=1 \
+		--env-file .release-env \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v `pwd`:/go/src/$(PACKAGE_NAME) \
+		-v `pwd`/sysroot:/sysroot \
+		-w /go/src/$(PACKAGE_NAME) \
+		ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
+                release --clean --skip-publish --skip-validate --config ../../goreleaser.yaml
+
+.PHONY: release
+release:
+	@if [ ! -f ".release-env" ]; then \
+		echo "\033[91m.release-env is required for release\033[0m";\
+		exit 1;\
+	fi
+	docker run \
+		--rm \
+		-e CGO_ENABLED=1 \
+		--env-file .release-env \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v `pwd`:/go/src/$(PACKAGE_NAME) \
+		-v `pwd`/sysroot:/sysroot \
+		-w /go/src/$(PACKAGE_NAME) \
+		ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
+		release --rm-dist

--- a/Makefile
+++ b/Makefile
@@ -66,4 +66,4 @@ release:
 		-v `pwd`/sysroot:/sysroot \
 		-w /go/src/$(PACKAGE_NAME) \
 		ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
-		release --rm-dist
+                release --clean

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/DeepSourceCorp/cli
+module github.com/deepsourcelabs/cli
 
 go 1.18
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/deepsourcelabs/cli
+module github.com/DeepSourceCorp/cli
 
 go 1.18
 

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -67,6 +67,7 @@ builds:
 
   # windows-amd64
   - id: "windows-deepsource"
+    main: ./cmd/deepsource
     env:
       - CGO_ENABLED=1
       - CC=x86_64-w64-mingw32-gcc
@@ -84,8 +85,7 @@ builds:
 archives:
   -
     name_template: >-
-      {{ .ProjectName }}_
-      {{- title .Os }}_
+      deepsource_{{ .Version }}_{{ .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -11,9 +11,6 @@ builds:
     flags:
       - -tags=static_all
     goos:
-      - freebsd
-      - openbsd
-      - netbsd
       - linux
       - darwin
     goarch:
@@ -24,7 +21,7 @@ builds:
       - "-X 'main.version={{ .Version }}' -X 'main.SentryDSN={{ .Env.DEEPSOURCE_CLI_SENTRY_DSN }}'"
   - id: "windows-deepsource"
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
     flags:
       - -tags=static_all
     goos:

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -1,35 +1,41 @@
 project_name: deepsource
+env:
+  - CGO_ENABLED=1
 
 before:
   hooks:
     - ../../scripts/gen-completions.sh
 
 builds:
-  -
+  - id: deepsource-darwin-amd64
     env:
       - CGO_ENABLED=1
+      - CC=o64-clang
+      - CXX=o64-clang++
     flags:
       - -tags=static_all
+      - "-mod={{ .Env.MOD }}"
+      - "-tags={{ .Env.BUILD_TAGS }}"
+      - -trimpath
     goos:
-      - linux
       - darwin
     goarch:
       - amd64
-      - arm64
     ldflags:
       - "-X 'main.version={{ .Version }}' -X 'main.SentryDSN={{ .Env.DEEPSOURCE_CLI_SENTRY_DSN }}'"
-  - id: "windows-deepsource"
-    env:
-      - CGO_ENABLED=1
-    flags:
-      - -tags=static_all
-    goos:
-      - windows
-    goarch:
-      - amd64
-    ldflags:
-      - buildmode=exe
-      - "-X 'main.version={{ .Version }}' -X 'main.SentryDSN={{ .Env.DEEPSOURCE_CLI_SENTRY_DSN }}'"
+
+  # - id: "windows-deepsource"
+  #   env:
+  #     - CGO_ENABLED=1
+  #   flags:
+  #     - -tags=static_all
+  #   goos:
+  #     - windows
+  #   goarch:
+  #     - amd64
+  #   ldflags:
+  #     - buildmode=exe
+  #     - "-X 'main.version={{ .Version }}' -X 'main.SentryDSN={{ .Env.DEEPSOURCE_CLI_SENTRY_DSN }}'"
 
 archives:
   -

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -14,9 +14,6 @@ builds:
       - CXX=o64-clang++
     flags:
       - -tags=static_all
-      - "-mod={{ .Env.MOD }}"
-      - "-tags={{ .Env.BUILD_TAGS }}"
-      - -trimpath
     goos:
       - darwin
     goarch:

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -14,7 +14,6 @@ builds:
       - linux
       - darwin
     goarch:
-      - 386
       - amd64
       - arm64
     ldflags:

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -1,5 +1,9 @@
 project_name: deepsource
 
+after:
+  hooks:
+    - scripts/gen-completions.sh
+
 builds:
   # darwin-amd64
   - id: deepsource-darwin-amd64

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -1,8 +1,7 @@
 project_name: deepsource
-env:
-  - CGO_ENABLED=1
 
 builds:
+  # darwin-amd64
   - id: deepsource-darwin-amd64
     main: ./cmd/deepsource
     env:
@@ -18,18 +17,69 @@ builds:
     ldflags:
       - "-X 'main.version={{ .Version }}' -X 'main.SentryDSN={{ .Env.DEEPSOURCE_CLI_SENTRY_DSN }}'"
 
-  # - id: "windows-deepsource"
-  #   env:
-  #     - CGO_ENABLED=1
-  #   flags:
-  #     - -tags=static_all
-  #   goos:
-  #     - windows
-  #   goarch:
-  #     - amd64
-  #   ldflags:
-  #     - buildmode=exe
-  #     - "-X 'main.version={{ .Version }}' -X 'main.SentryDSN={{ .Env.DEEPSOURCE_CLI_SENTRY_DSN }}'"
+  # darwin-arm64
+  - id: deepsource-darwin-arm64
+    main: ./cmd/deepsource
+    env:
+      - CGO_ENABLED=1
+      - CC=o64-clang
+      - CXX=o64-clang++
+    flags:
+      - -tags=static_all
+    goos:
+      - darwin
+    goarch:
+      - arm64
+    ldflags:
+      - "-X 'main.version={{ .Version }}' -X 'main.SentryDSN={{ .Env.DEEPSOURCE_CLI_SENTRY_DSN }}'"
+
+  # linux-amd64
+  - id: deepsource-linux-amd64
+    main: ./cmd/deepsource
+    env:
+      - CGO_ENABLED=1
+      - CC=x86_64-linux-gnu-gcc
+      - CXX=x86_64-linux-gnu-g++
+    flags:
+      - -tags=static_all
+    goos:
+      - linux
+    goarch:
+      - amd64
+    ldflags:
+      - "-X 'main.version={{ .Version }}' -X 'main.SentryDSN={{ .Env.DEEPSOURCE_CLI_SENTRY_DSN }}'"
+
+  # linux-arm64
+  - id: deepsource-linux-arm64
+    main: ./cmd/deepsource
+    env:
+      - CGO_ENABLED=1
+      - CC=aarch64-linux-gnu-gcc
+      - CXX=aarch64-linux-gnu-g++
+    flags:
+      - -tags=static_all
+    goos:
+      - linux
+    goarch:
+      - arm64
+    ldflags:
+      - "-X 'main.version={{ .Version }}' -X 'main.SentryDSN={{ .Env.DEEPSOURCE_CLI_SENTRY_DSN }}'"
+
+  # windows-amd64
+  - id: "windows-deepsource"
+    env:
+      - CGO_ENABLED=1
+      - CC=x86_64-w64-mingw32-gcc
+      - CXX=x86_64-w64-mingw32-g++
+    flags:
+      - -tags=static_all
+    goos:
+      - windows
+    goarch:
+      - amd64
+    ldflags:
+      - buildmode=exe
+      - "-X 'main.version={{ .Version }}' -X 'main.SentryDSN={{ .Env.DEEPSOURCE_CLI_SENTRY_DSN }}'"
 
 archives:
   -

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -1,6 +1,6 @@
 project_name: deepsource
 
-after:
+before:
   hooks:
     - scripts/gen-completions.sh
 

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -2,12 +2,9 @@ project_name: deepsource
 env:
   - CGO_ENABLED=1
 
-before:
-  hooks:
-    - ../../scripts/gen-completions.sh
-
 builds:
   - id: deepsource-darwin-amd64
+    main: ./cmd/deepsource
     env:
       - CGO_ENABLED=1
       - CC=o64-clang

--- a/scripts/gen-completions.sh
+++ b/scripts/gen-completions.sh
@@ -6,5 +6,5 @@ mkdir completions
 
 # Generate completion using the in-built cobra completion command
 for shell in bash zsh fish; do
-  go run main.go completion "$shell" > "completions/deepsource.$shell"
+  go run cmd/deepsource/main.go completion "$shell" > "completions/deepsource.$shell"
 done


### PR DESCRIPTION
Fixes the Goreleaser pipeline for CGO builds. We need CGO in CLI now since we compress the artifacts using zstd. This PR introduces [goreleaser-cross](https://github.com/goreleaser/goreleaser-cross) docker image to build the binaries for linux, darwin and windows operating systems and removes BSD based OS support since its not supported in cross compilation.