### PR TITLE
fix: add `.release-env` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Vendor files
 vendor
-release-env
+.release-env
 
 # Executable
 cmd/deepsource/deepsource

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Vendor files
 vendor
+release-env
 
 # Executable
 cmd/deepsource/deepsource


### PR DESCRIPTION
Adds `.release-env` to `.gitignore` for Goreleaser to not throw `Git is in a dirty state` error.