### PR TITLE
chore: change homebrew tap organization to DeepSourceCorp

### DIFF
--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -105,7 +105,7 @@ changelog:
 
 brews:
   - tap:
-      owner: deepsourcelabs
+      owner: DeepSourceCorp
       name: homebrew-cli
       branch: cli-release
       token: "{{ .Env.HOMEBREW_TOKEN }}"


### PR DESCRIPTION
Changes the homebrew tap org to DeepSourceCorp. The tap is located at [DeepSourceCorp/homebrew-cli](https://github.com/DeepSourceCorp/homebrew-cli)