### PR TITLE
hotfix: don't early exit with error if root is not a git dir

### DIFF
--- a/command/report/git.go
+++ b/command/report/git.go
@@ -2,12 +2,9 @@ package report
 
 import (
 	"bytes"
-	"fmt"
 	"os"
 	"os/exec"
 	"strings"
-
-	"github.com/getsentry/sentry-go"
 )
 
 // gitGetHead accepts a git directory and returns head commit OID / error
@@ -18,13 +15,8 @@ func gitGetHead(workspaceDir string) (headOID string, warning string, err error)
 		return
 	}
 
-	// get the top commit manually, using git command
+	// get the top commit manually, using git command. We will be using this if there's no env variable set for extracting commit.
 	headOID, err = fetchHeadManually(workspaceDir)
-	if err != nil {
-		fmt.Println(err)
-		sentry.CaptureException(err)
-		return
-	}
 
 	// TRAVIS CI
 	if envUser := os.Getenv("USER"); envUser == "travis" {

--- a/command/report/git.go
+++ b/command/report/git.go
@@ -23,8 +23,8 @@ func gitGetHead(workspaceDir string) (headOID string, warning string, err error)
 	// Example:
 	// GIT_COMMIT_SHA=$(git --no-pager rev-parse HEAD | tr -d '\n')
 	// docker run -e DEEPSOURCE_DSN -e GIT_COMMIT_SHA ...
-	if _, isManuallyInjectedSHA := os.LookupEnv("GIT_COMMIT_SHA"); isManuallyInjectedSHA {
-		return os.Getenv("GIT_COMMIT_SHA"), "", nil
+	if injectedSHA, isManuallyInjectedSHA := os.LookupEnv("GIT_COMMIT_SHA"); isManuallyInjectedSHA {
+		return injectedSHA, "", nil
 	}
 
 	// get the top commit manually, using git command. We will be using this if there's no env variable set for extracting commit.

--- a/command/report/report.go
+++ b/command/report/report.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"strings"
 	"time"
@@ -182,6 +183,7 @@ func (opts *ReportOptions) Run() int {
 	headCommitOID, warning, err := gitGetHead(currentDir)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "DeepSource | Error | Unable to get commit OID HEAD. Make sure you are running the CLI from a git repository")
+		log.Println(err)
 		sentry.CaptureException(err)
 		return 1
 	}


### PR DESCRIPTION
This broke reporting workflow in a case where an artifact was being reported from a docker container. Previously, Fetching HEAD manually was done in the end, after checking all env variables. In the last change, we were doing an early exit when the `git rev-parse` command threw an error, not allowing the flow to reach extracting git commit from env variable set in the docker container.

This change restores the previous workflow.