### PR TITLE
chore: check supported keys only for test-coverage

### DIFF
--- a/command/report/report.go
+++ b/command/report/report.go
@@ -127,7 +127,7 @@ func (opts *ReportOptions) Run() int {
 		return keys
 	}
 
-	if !supportedKeys[reportCommandKey] {
+	if reportCommandAnalyzerShortcode == "test-coverage" && !supportedKeys[reportCommandKey] {
 		err = fmt.Errorf("DeepSource | Error | Invalid Key: %s (Supported Keys: %v)", reportCommandKey, allowedKeys(supportedKeys))
 		fmt.Fprintln(os.Stderr, err)
 		sentry.CaptureException(err)


### PR DESCRIPTION
`key` is an optional flag, and is only used by the test coverage analyzer to identify the language for the report.

Previously, the check would always fail since it was matching against a whitelist of supported keys. This PR changes the behavior to check it only for test-coverage artifact reporting. 