### PR TITLE
fix: include completions/ dir in releases

### DIFF
--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -87,12 +87,13 @@ builds:
       - "-X 'main.version={{ .Version }}' -X 'main.SentryDSN={{ .Env.DEEPSOURCE_CLI_SENTRY_DSN }}'"
 
 archives:
-  -
-    name_template: >-
+  - name_template: >-
       deepsource_{{ .Version }}_{{ .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
+    files:
+      - completions/**/*
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
This fixes the `Errno::ENOENT: No such file or directory - completions/deepsource.*` issue when installing using homebrew.