### PR TITLE
chore: use oidc to report coverage

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,8 +9,6 @@ on:
 jobs:
   run-tests:
     runs-on: ubuntu-latest
-    env:
-        DEEPSOURCE_DSN: ${{ secrets.DEEPSOURCE_DSN }}
 
     steps:
       - name: Set up Go 1.x
@@ -40,4 +38,4 @@ jobs:
       - name: Report test coverage to DeepSource
         run: |
           curl https://deepsource.io/cli | sh
-          ./bin/deepsource report --analyzer test-coverage --key go --value-file ./coverage.out
+          ./bin/deepsource report --analyzer test-coverage --key go --value-file ./coverage.out --use-oidc

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   run-tests:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required to fetch the OIDC token
 
     steps:
       - name: Set up Go 1.x

--- a/utils/fetch_oidc_token_test.go
+++ b/utils/fetch_oidc_token_test.go
@@ -284,7 +284,7 @@ func TestGetDSNFromOIDC(t *testing.T) {
 		t.Setenv("GITHUB_ACTIONS", "true")
 		// ACTIONS_ID_TOKEN_REQUEST_TOKEN is missing
 		t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", "url")
-		// make sure this is missing in when running on github actions too
+		// make sure this is missing when running on github actions too
 		os.Unsetenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
 		t.Cleanup(func() {
 			os.Unsetenv("GITHUB_ACTIONS")

--- a/utils/fetch_oidc_token_test.go
+++ b/utils/fetch_oidc_token_test.go
@@ -284,6 +284,8 @@ func TestGetDSNFromOIDC(t *testing.T) {
 		t.Setenv("GITHUB_ACTIONS", "true")
 		// ACTIONS_ID_TOKEN_REQUEST_TOKEN is missing
 		t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", "url")
+		// make sure this is missing in when running on github actions too
+		os.Unsetenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
 		t.Cleanup(func() {
 			os.Unsetenv("GITHUB_ACTIONS")
 			os.Unsetenv("ACTIONS_ID_TOKEN_REQUEST_URL")
@@ -300,6 +302,7 @@ func TestGetDSNFromOIDC(t *testing.T) {
 	t.Run("error_github_actions_env_vars_missing_url", func(t *testing.T) {
 		t.Setenv("GITHUB_ACTIONS", "true")
 		t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "token")
+		os.Unsetenv("ACTIONS_ID_TOKEN_REQUEST_URL")
 		// ACTIONS_ID_TOKEN_REQUEST_URL is missing
 		t.Cleanup(func() {
 			os.Unsetenv("GITHUB_ACTIONS")


### PR DESCRIPTION
- remove `DEEPSOURCE_DSN` from env
- add required permissions for getting OIDC token
- change cli command to use oidc instead
- fix oidc tests